### PR TITLE
Widen integrations-api to provide a name for a given key

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.cryptomator</groupId>
     <artifactId>integrations-api</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.1.0</version>
 
     <name>Cryptomator Integrations API</name>
     <description>Defines optional service interfaces that may be used by Cryptomator</description>
@@ -72,6 +72,7 @@
                 </executions>
                 <configuration>
                     <quiet>true</quiet>
+					<javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                     <release>11</release>
                     <tags>
                         <!-- workaround for "unknown tag: implNote", see https://blog.codefx.org/java/new-javadoc-tags/#Maven  -->

--- a/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
+++ b/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
@@ -58,6 +58,18 @@ public interface KeychainAccessProvider {
 	void changePassphrase(String key, CharSequence passphrase) throws KeychainAccessException;
 
 	/**
+	 * Updates a passphrase with a given key and stores a name for that key. Noop, if there is no item for the given key.
+	 *
+	 * @param key         Unique key previously used while {@link #storePassphrase(String, CharSequence) storing a passphrase}.
+	 * @param displayName The according name to the key.
+	 * @param passphrase  The secret to be updated in this keychain.
+	 * @throws KeychainAccessException If changing the password failed
+	 */
+	default void changePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
+		changePassphrase(key, passphrase);
+	}
+
+	/**
 	 * @return <code>true</code> if this KeychainAccessIntegration works on the current machine.
 	 * @implSpec This method must not throw any exceptions and should fail fast
 	 * returning <code>false</code> if it can't determine availability of the checked strategy

--- a/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
+++ b/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
@@ -22,6 +22,16 @@ public interface KeychainAccessProvider {
 	void storePassphrase(String key, CharSequence passphrase) throws KeychainAccessException;
 
 	/**
+	 * Associates a passphrase with a given key and a name for that key.
+	 *
+	 * @param key        Key used to retrieve the passphrase via {@link #loadPassphrase(String)}.
+	 * @param name       The according name to the key.
+	 * @param passphrase The secret to store in this keychain.
+	 * @throws KeychainAccessException If storing the password failed
+	 */
+	default void storePassphrase(String key, String name, CharSequence passphrase) throws KeychainAccessException { }
+
+	/**
 	 * @param key Unique key previously used while {@link #storePassphrase(String, CharSequence) storing a passphrase}.
 	 * @return The stored passphrase for the given key or <code>null</code> if no value for the given key could be found.
 	 * @throws KeychainAccessException If loading the password failed

--- a/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
+++ b/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
@@ -24,12 +24,14 @@ public interface KeychainAccessProvider {
 	/**
 	 * Associates a passphrase with a given key and a name for that key.
 	 *
-	 * @param key        Key used to retrieve the passphrase via {@link #loadPassphrase(String)}.
-	 * @param name       The according name to the key.
-	 * @param passphrase The secret to store in this keychain.
+	 * @param key         Key used to retrieve the passphrase via {@link #loadPassphrase(String)}.
+	 * @param displayName The according name to the key.
+	 * @param passphrase  The secret to store in this keychain.
 	 * @throws KeychainAccessException If storing the password failed
 	 */
-	default void storePassphrase(String key, String name, CharSequence passphrase) throws KeychainAccessException { }
+	default void storePassphrase(String key, String displayName, CharSequence passphrase) throws KeychainAccessException {
+		storePassphrase(key, passphrase);
+	}
 
 	/**
 	 * @param key Unique key previously used while {@link #storePassphrase(String, CharSequence) storing a passphrase}.


### PR DESCRIPTION
The change passes the `displayName` of a vault to a keychain backend, namely the `storePassphrase` and `deletePassphrase` methods.

Having the `displayName` enables the backend to process and store it.

The change should be non-disruptive, which means that backends that have no interest in the new parameter `displayName` do not need to be changed due to this API change.

Cryptomator itself needs a change too, in order to make use of this change. [Another PR](https://github.com/purejava/cryptomator/tree/feature/displayName) takes care of that.