### PR TITLE
Integrated Service Loading

### DIFF
--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,6 +1,16 @@
+import org.cryptomator.integrations.autostart.AutoStartProvider;
+import org.cryptomator.integrations.keychain.KeychainAccessProvider;
+import org.cryptomator.integrations.tray.TrayIntegrationProvider;
+import org.cryptomator.integrations.uiappearance.UiAppearanceProvider;
+
 module org.cryptomator.integrations.api {
 	exports org.cryptomator.integrations.autostart;
 	exports org.cryptomator.integrations.keychain;
 	exports org.cryptomator.integrations.tray;
 	exports org.cryptomator.integrations.uiappearance;
+
+	uses AutoStartProvider;
+	uses KeychainAccessProvider;
+	uses TrayIntegrationProvider;
+	uses UiAppearanceProvider;
 }

--- a/src/main/java/org/cryptomator/integrations/autostart/AutoStartProvider.java
+++ b/src/main/java/org/cryptomator/integrations/autostart/AutoStartProvider.java
@@ -1,6 +1,14 @@
 package org.cryptomator.integrations.autostart;
 
+import org.cryptomator.integrations.common.IntegrationsLoader;
+
+import java.util.Optional;
+
 public interface AutoStartProvider {
+
+	static Optional<AutoStartProvider> get() {
+		return IntegrationsLoader.load(AutoStartProvider.class);
+	}
 
 	void enable() throws ToggleAutoStartFailedException;
 

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -1,0 +1,38 @@
+package org.cryptomator.integrations.common;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+public class IntegrationsLoader {
+
+	/**
+	 * Loads the best suited service, i.e. the one with the highest priority that is supported.
+	 * <p>
+	 * If two services are available with the same priority, it is unspecified which one will be returned.
+	 *
+	 * @param clazz Service class
+	 * @param <T>   Type of the service
+	 * @return Highest priority service or empty if no supported service was found
+	 */
+	public static <T> Optional<T> load(Class<T> clazz) {
+		return ServiceLoader.load(clazz)
+				.stream()
+				.filter(IntegrationsLoader::isSupportedOperatingSystem)
+				.sorted(Comparator.comparingInt(IntegrationsLoader::getPriority))
+				.map(ServiceLoader.Provider::get)
+				.findFirst();
+	}
+
+	private static int getPriority(ServiceLoader.Provider<?> provider) {
+		var prio = provider.type().getAnnotation(Priority.class);
+		return prio == null ? Priority.DEFAULT : prio.value();
+	}
+
+	private static boolean isSupportedOperatingSystem(ServiceLoader.Provider<?> provider) {
+		var annotations = provider.type().getAnnotationsByType(OperatingSystem.class);
+		return annotations.length == 0 || Arrays.stream(annotations).anyMatch(OperatingSystem.Value::isCurrent);
+	}
+
+}

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.ServiceLoader;
+import java.util.stream.Stream;
 
 public class IntegrationsLoader {
 
@@ -17,12 +18,22 @@ public class IntegrationsLoader {
 	 * @return Highest priority service or empty if no supported service was found
 	 */
 	public static <T> Optional<T> load(Class<T> clazz) {
+		return loadAll(clazz).findFirst();
+	}
+
+	/**
+	 * Loads all suited services ordered by priority in descending order.
+	 *
+	 * @param clazz Service class
+	 * @param <T>   Type of the service
+	 * @return An ordered stream of all suited service candidates
+	 */
+	public static <T> Stream<T> loadAll(Class<T> clazz) {
 		return ServiceLoader.load(clazz)
 				.stream()
 				.filter(IntegrationsLoader::isSupportedOperatingSystem)
-				.sorted(Comparator.comparingInt(IntegrationsLoader::getPriority))
-				.map(ServiceLoader.Provider::get)
-				.findFirst();
+				.sorted(Comparator.comparingInt(IntegrationsLoader::getPriority).reversed())
+				.map(ServiceLoader.Provider::get);
 	}
 
 	private static int getPriority(ServiceLoader.Provider<?> provider) {

--- a/src/main/java/org/cryptomator/integrations/common/OperatingSystem.java
+++ b/src/main/java/org/cryptomator/integrations/common/OperatingSystem.java
@@ -30,7 +30,7 @@ public @interface OperatingSystem {
 		WINDOWS,
 		UNKNOWN;
 
-		private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+		private static final String OS_NAME = System.getProperty("os.name", "").toLowerCase();
 
 		public static Value current() {
 			if (OS_NAME.contains("linux")) {

--- a/src/main/java/org/cryptomator/integrations/common/OperatingSystem.java
+++ b/src/main/java/org/cryptomator/integrations/common/OperatingSystem.java
@@ -1,0 +1,51 @@
+package org.cryptomator.integrations.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Restricts the annotated integration provider to one or more operating system(s).
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+@Repeatable(OperatingSystem.OperatingSystems.class)
+public @interface OperatingSystem {
+	Value value() default Value.UNKNOWN;
+
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ElementType.TYPE})
+	@interface OperatingSystems {
+		OperatingSystem[] value();
+	}
+
+	enum Value {
+		LINUX,
+		MAC,
+		WINDOWS,
+		UNKNOWN;
+
+		private static final String OS_NAME = System.getProperty("os.name").toLowerCase();
+
+		public static Value current() {
+			if (OS_NAME.contains("linux")) {
+				return LINUX;
+			} else if (OS_NAME.contains("mac")) {
+				return MAC;
+			} else if (OS_NAME.contains("windows")) {
+				return WINDOWS;
+			} else {
+				return UNKNOWN;
+			}
+		}
+
+		public static boolean isCurrent(OperatingSystem os) {
+			return current().equals(os.value());
+		}
+	}
+}

--- a/src/main/java/org/cryptomator/integrations/common/Priority.java
+++ b/src/main/java/org/cryptomator/integrations/common/Priority.java
@@ -1,0 +1,23 @@
+package org.cryptomator.integrations.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Integration Priority.
+ * <p>
+ * If multiple implementations for an integration can be provided, the provider with the highest priority will be used.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface Priority {
+	int DEFAULT = 0;
+	int FALLBACK = Integer.MIN_VALUE;
+
+	int value() default DEFAULT;
+}

--- a/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
+++ b/src/main/java/org/cryptomator/integrations/keychain/KeychainAccessProvider.java
@@ -1,9 +1,17 @@
 package org.cryptomator.integrations.keychain;
 
+import org.cryptomator.integrations.common.IntegrationsLoader;
+
+import java.util.stream.Stream;
+
 /**
  * This is the interface used by Cryptomator to store passwords securely in external keychains, such as system keychains or password managers.
  */
 public interface KeychainAccessProvider {
+
+	static Stream<KeychainAccessProvider> get() {
+		return IntegrationsLoader.loadAll(KeychainAccessProvider.class).filter(KeychainAccessProvider::isSupported);
+	}
 
 	/**
 	 * A name to display in UI elements. If required, this should be localized.

--- a/src/main/java/org/cryptomator/integrations/tray/TrayIntegrationProvider.java
+++ b/src/main/java/org/cryptomator/integrations/tray/TrayIntegrationProvider.java
@@ -1,6 +1,14 @@
 package org.cryptomator.integrations.tray;
 
+import org.cryptomator.integrations.common.IntegrationsLoader;
+
+import java.util.Optional;
+
 public interface TrayIntegrationProvider {
+
+	static Optional<TrayIntegrationProvider> get() {
+		return IntegrationsLoader.load(TrayIntegrationProvider.class);
+	}
 
 	/**
 	 * Performs tasks required when the application is no longer showing any window and only accessible via

--- a/src/main/java/org/cryptomator/integrations/uiappearance/UiAppearanceProvider.java
+++ b/src/main/java/org/cryptomator/integrations/uiappearance/UiAppearanceProvider.java
@@ -1,9 +1,17 @@
 package org.cryptomator.integrations.uiappearance;
 
+import org.cryptomator.integrations.common.IntegrationsLoader;
+
+import java.util.Optional;
+
 /**
  * This is the interface used by Cryptomator to get os specific UI appearances and themes.
  */
 public interface UiAppearanceProvider {
+
+	static Optional<UiAppearanceProvider> get() {
+		return IntegrationsLoader.load(UiAppearanceProvider.class);
+	}
 
 	/**
 	 * Gets the best-matching theme for the OS's current L&amp;F. This might be an approximation, as the OS might support more variations than we do.


### PR DESCRIPTION
This improves service loading by adding an `IntegrationsLoader` that uses annotations to sort and filter implementation candidates.

Furthermore static "factory" methods have been added to all current services.

## Sorting

Using the `@Priority(42)` annotation, we can make a certain service implementation take precedence over others, allowing us to implement fallback mechanisms easily.

## Filtering

This allows us (to a certain degree) to check whether a certain service implementation is suited for e.g. the current operating system (using the `@OperatingSystem(Value.Windows)` annotation) without actually creating an instance of said service. Further discriminators may be added on demand eventually.

