### PR TITLE
Add some log statements during plugin loading

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,10 +39,22 @@
 
 	<dependencies>
 		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>1.7.36</version>
+		</dependency>
+
+		<dependency>
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
 			<version>23.0.0</version>
 			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>1.7.36</version>
+			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -7,6 +7,7 @@ import org.cryptomator.integrations.uiappearance.UiAppearanceProvider;
 
 module org.cryptomator.integrations.api {
 	requires static org.jetbrains.annotations;
+	requires org.slf4j;
 
 	exports org.cryptomator.integrations.autostart;
 	exports org.cryptomator.integrations.common;

--- a/src/main/java/org/cryptomator/integrations/common/ClassLoaderFactory.java
+++ b/src/main/java/org/cryptomator/integrations/common/ClassLoaderFactory.java
@@ -2,6 +2,8 @@ package org.cryptomator.integrations.common;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -10,9 +12,12 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.stream.Collectors;
 
 class ClassLoaderFactory {
 
+	private static final Logger LOG = LoggerFactory.getLogger(ClassLoaderFactory.class);
 	private static final String USER_HOME = System.getProperty("user.home");
 	private static final String PLUGIN_DIR_KEY = "cryptomator.pluginDir";
 	private static final String JAR_SUFFIX = ".jar";
@@ -38,7 +43,12 @@ class ClassLoaderFactory {
 	@VisibleForTesting
 	@Contract(value = "_ -> new", pure = true)
 	static URLClassLoader forPluginDirWithPath(Path path) throws UncheckedIOException {
-		return URLClassLoader.newInstance(findJars(path));
+		var jars = findJars(path);
+		if (LOG.isDebugEnabled()) {
+			String jarList = Arrays.stream(jars).map(URL::getPath).collect(Collectors.joining(", "));
+			LOG.debug("Found jars in cryptomator.pluginDir: {}", jarList);
+		}
+		return URLClassLoader.newInstance(jars);
 	}
 
 	@VisibleForTesting

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -2,6 +2,8 @@ package org.cryptomator.integrations.common;
 
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.VisibleForTesting;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -12,6 +14,8 @@ import java.util.ServiceLoader;
 import java.util.stream.Stream;
 
 public class IntegrationsLoader {
+
+	private static final Logger LOG = LoggerFactory.getLogger(IntegrationsLoader.class);
 
 	private IntegrationsLoader() {
 	}
@@ -39,11 +43,19 @@ public class IntegrationsLoader {
 	public static <T> Stream<T> loadAll(Class<T> clazz) {
 		return ServiceLoader.load(clazz, ClassLoaderFactory.forPluginDir())
 				.stream()
+				.peek(service -> logFoundService(clazz, service.type()))
 				.filter(IntegrationsLoader::isSupportedOperatingSystem)
 				.filter(IntegrationsLoader::passesStaticAvailabilityCheck)
 				.sorted(Comparator.comparingInt(IntegrationsLoader::getPriority).reversed())
 				.map(ServiceLoader.Provider::get)
-				.filter(IntegrationsLoader::passesInstanceAvailabilityCheck);
+				.filter(IntegrationsLoader::passesInstanceAvailabilityCheck)
+				.peek(impl -> logServiceIsAvailable(clazz, impl.getClass()));
+	}
+
+	private static void logFoundService(Class<?> apiType, Class<?> implType) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("{}: Found implementation: {} in jar {}", apiType.getSimpleName(), implType.getName(), implType.getProtectionDomain().getCodeSource().getLocation().getPath());
+		}
 	}
 
 	private static int getPriority(ServiceLoader.Provider<?> provider) {
@@ -70,9 +82,19 @@ public class IntegrationsLoader {
 		return passesAvailabilityCheck(instance.getClass(), instance);
 	}
 
+	private static void logServiceIsAvailable(Class<?> apiType, Class<?> implType) {
+		if (LOG.isDebugEnabled()) {
+			LOG.debug("{}: Implementation is available: {}", apiType.getSimpleName(), implType.getName());
+		}
+	}
+
 	private static <T> boolean passesAvailabilityCheck(Class<? extends T> type, @Nullable T instance) {
 		if (!type.isAnnotationPresent(CheckAvailability.class)) {
 			return true; // if type is not annotated, skip tests
+		}
+		if (!type.getModule().isExported(type.getPackageName(), IntegrationsLoader.class.getModule())) {
+			LOG.warn("Can't run @CheckAvailability tests for class {}. Make sure to export {} to {}!", type.getName(), type.getPackageName(), IntegrationsLoader.class.getPackageName());
+			return false;
 		}
 		return Arrays.stream(type.getMethods())
 				.filter(m -> isAvailabilityCheck(m, instance == null))
@@ -84,6 +106,7 @@ public class IntegrationsLoader {
 		try {
 			return (boolean) m.invoke(instance);
 		} catch (ReflectiveOperationException e) {
+			LOG.warn("Failed to invoke @CheckAvailability test {}#{}", m.getDeclaringClass(), m.getName(), e);
 			return false;
 		}
 	}

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -93,7 +93,7 @@ public class IntegrationsLoader {
 			return true; // if type is not annotated, skip tests
 		}
 		if (!type.getModule().isExported(type.getPackageName(), IntegrationsLoader.class.getModule())) {
-			LOG.warn("Can't run @CheckAvailability tests for class {}. Make sure to export {} to {}!", type.getName(), type.getPackageName(), IntegrationsLoader.class.getPackageName());
+			LOG.error("Can't run @CheckAvailability tests for class {}. Make sure to export {} to {}!", type.getName(), type.getPackageName(), IntegrationsLoader.class.getPackageName());
 			return false;
 		}
 		return Arrays.stream(type.getMethods())


### PR DESCRIPTION
fixes #9

Example Output:

```
15:20:00.578 [JavaFX Application Thread] DEBUG o.c.i.common.ClassLoaderFactory - Found jars in cryptomator.pluginDir: /Users/sebastian/Library/Application%20Support/Cryptomator/Plugins/keepassxc-cryptomator-1.1.0.jar
15:20:00.580 [JavaFX Application Thread] DEBUG o.c.i.common.IntegrationsLoader - TrayMenuController: Found implementation: org.cryptomator.ui.traymenu.AwtTrayMenuController in jar /Users/sebastian/Documents/Cryptomator/Desktop/target/classes/
15:20:00.582 [JavaFX Application Thread] WARN  o.c.i.common.IntegrationsLoader - Can't run @CheckAvailability tests for class org.cryptomator.ui.traymenu.AwtTrayMenuController. Make sure to export org.cryptomator.ui.traymenu to org.cryptomator.integrations.common!
...
15:20:01.115 [JavaFX Application Thread] DEBUG o.c.i.common.ClassLoaderFactory - Found jars in cryptomator.pluginDir: /Users/sebastian/Library/Application%20Support/Cryptomator/Plugins/keepassxc-cryptomator-1.1.0.jar
15:20:01.117 [JavaFX Application Thread] DEBUG o.c.i.common.IntegrationsLoader - KeychainAccessProvider: Found implementation: org.cryptomator.macos.keychain.MacSystemKeychainAccess in jar /Users/sebastian/.m2/repository/org/cryptomator/integrations-mac/1.1.0-beta1/integrations-mac-1.1.0-beta1.jar
15:20:01.119 [JavaFX Application Thread] DEBUG o.c.i.common.IntegrationsLoader - KeychainAccessProvider: Found implementation: org.purejava.integrations.keychain.KeePassXCAccess in jar /Users/sebastian/Library/Application%20Support/Cryptomator/Plugins/keepassxc-cryptomator-1.1.0.jar
15:20:01.120 [JavaFX Application Thread] DEBUG o.c.i.common.IntegrationsLoader - KeychainAccessProvider: Implementation is available: org.cryptomator.macos.keychain.MacSystemKeychainAccess
15:20:01.140 [JavaFX Application Thread] DEBUG o.c.i.common.IntegrationsLoader - KeychainAccessProvider: Implementation is available: org.purejava.integrations.keychain.KeePassXCAccess
```