### PR TITLE
polymorphic tray icon loading

### DIFF
--- a/src/main/java/org/cryptomator/integrations/tray/TrayIconLoader.java
+++ b/src/main/java/org/cryptomator/integrations/tray/TrayIconLoader.java
@@ -1,0 +1,27 @@
+package org.cryptomator.integrations.tray;
+
+/**
+ * A callback used by the {@link TrayMenuController} to load tray icons in the format required by the implementation.
+ */
+sealed public interface TrayIconLoader permits TrayIconLoader.PngData, TrayIconLoader.FreedesktopIconName {
+
+	non-sealed interface PngData extends TrayIconLoader {
+
+		/**
+		 * Loads an icon from a byte array holding a loaded PNG file.
+		 *
+		 * @param data png data
+		 */
+		void loadPng(byte[] data);
+	}
+
+	non-sealed interface FreedesktopIconName extends TrayIconLoader {
+
+		/**
+		 * Loads an icon by looking it up {@code iconName} inside of {@code $XDG_DATA_DIRS/icons}.
+		 *
+		 * @param iconName the icon name
+		 */
+		void lookupByName(String iconName);
+	}
+}

--- a/src/main/java/org/cryptomator/integrations/tray/TrayIconLoader.java
+++ b/src/main/java/org/cryptomator/integrations/tray/TrayIconLoader.java
@@ -1,10 +1,14 @@
 package org.cryptomator.integrations.tray;
 
+import org.jetbrains.annotations.ApiStatus;
+
 /**
  * A callback used by the {@link TrayMenuController} to load tray icons in the format required by the implementation.
  */
+@ApiStatus.Experimental
 sealed public interface TrayIconLoader permits TrayIconLoader.PngData, TrayIconLoader.FreedesktopIconName {
 
+	@FunctionalInterface
 	non-sealed interface PngData extends TrayIconLoader {
 
 		/**
@@ -15,6 +19,7 @@ sealed public interface TrayIconLoader permits TrayIconLoader.PngData, TrayIconL
 		void loadPng(byte[] data);
 	}
 
+	@FunctionalInterface
 	non-sealed interface FreedesktopIconName extends TrayIconLoader {
 
 		/**

--- a/src/main/java/org/cryptomator/integrations/tray/TrayMenuController.java
+++ b/src/main/java/org/cryptomator/integrations/tray/TrayMenuController.java
@@ -3,9 +3,9 @@ package org.cryptomator.integrations.tray;
 import org.cryptomator.integrations.common.IntegrationsLoader;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 /**
  * Displays a tray icon and menu
@@ -22,20 +22,20 @@ public interface TrayMenuController {
 	/**
 	 * Displays an icon on the system tray.
 	 *
-	 * @param imageUri      What image to show
+	 * @param iconLoader    A callback responsible for retrieving the icon in the required format
 	 * @param defaultAction Action to perform when interacting with the icon directly instead of its menu
 	 * @param tooltip       Text shown when hovering
 	 * @throws TrayMenuException thrown when adding the tray icon failed
 	 */
-	void showTrayIcon(URI imageUri, Runnable defaultAction, String tooltip) throws TrayMenuException;
+	void showTrayIcon(Consumer<TrayIconLoader> iconLoader, Runnable defaultAction, String tooltip) throws TrayMenuException;
 
 	/**
 	 * Updates the icon on the system tray.
 	 *
-	 * @param imageUri What image to show
+	 * @param iconLoader A callback responsible for retrieving the icon in the required format
 	 * @throws IllegalStateException thrown when called before an icon has been added
 	 */
-	void updateTrayIcon(URI imageUri);
+	void updateTrayIcon(Consumer<TrayIconLoader> iconLoader);
 
 	/**
 	 * Show the given options in the tray menu.


### PR DESCRIPTION
This is an attempt to solve the problem mentioned in https://github.com/cryptomator/integrations-api/pull/17#issuecomment-1531700076:

Using sealed classes and IoC, we can now let the implementation decide, which kind of icon it needs, e.g.

```java
class PngConsumingTrayMenuController implements TrayMenuController {
    // ...
    public void updateTrayIcon(Consumer<TrayIconLoader> iconLoader) {
        TrayIconLoader.PngData callback = this::updateTrayIconWithPngData;
        iconLoader.accept(callback);
    }
    
    private void updateTrayIconWithPngData(byte[] data) {
        // ...
    }
    // ...
}
```

On the consumer side, invocation would look like this:

```java
// with JEP 433:
updateTrayIcon(loader -> {
	switch (loader) {
		case TrayIconLoader.PngData l -> l.loadPng(new byte[0]);
		case TrayIconLoader.FreedesktopIconName l -> l.lookupByName("foo");
	}
});

// without JEP 433:
updateTrayIcon(loader -> {
	if (loader instanceof TrayIconLoader.PngData l) {
		l.loadPng(new byte[0]);
	} else if (loader instanceof TrayIconLoader.FreedesktopIconName l) {
		l.lookupByName("");
	}
});
```

Note that the consumer is only required to implement loaders permitted by the sealed interface, so there can only be as many required implementation as the API allows:

https://github.com/cryptomator/integrations-api/blob/cdf313e4feb132714c9cb2ec895036f7ec97a3c0/src/main/java/org/cryptomator/integrations/tray/TrayIconLoader.java#L6

When the API is updated, new implementations can be added without breaking previous ones. With JEP 433, one will even get a compiler error due to exhaustiveness checks, if an implementation is missing.