### PR TITLE
Feature:  Robust service provider loading

### DIFF
--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -74,15 +74,10 @@ public class IntegrationsLoader {
 			return Stream.of(provider.get());
 		} catch (ServiceConfigurationError err) {
 			//ServiceLoader.Provider::get throws this error if (from javadoc)
-			if (err.getCause() == null || //the public static "provider()" method of a provider factory returns null
-					err.getCause() instanceof ExceptionInInitializerError || // * the service provider cannot be instantiated,
-					err.getCause() instanceof NoClassDefFoundError ||
-					err.getCause() instanceof RuntimeException) {
-				LOG.warn("Unable to load service provider {}.", provider.type().getName(), err);
-				return Stream.empty();
-			} else {
-				throw err;
-			}
+			// * the public static "provider()" method of a provider factory returns null
+			// * the service provider cannot be instantiated due to an error/throw
+			LOG.warn("Unable to load service provider {}.", provider.type().getName(), err);
+			return Stream.empty();
 		}
 	}
 

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -87,27 +87,26 @@ public class IntegrationsLoader {
 
 	@VisibleForTesting
 	static boolean passesStaticAvailabilityCheck(Class<?> type) {
-		try {
-			return passesAvailabilityCheck(type, null);
-		} catch (ExceptionInInitializerError | NoClassDefFoundError | RuntimeException t) {
-			LOG.warn("Unable to load service provider {}.", type.getName(), t);
-			return false;
-		}
+		return silentlyPassesAvailabilityCheck(type, null);
 	}
 
 	@VisibleForTesting
 	static boolean passesInstanceAvailabilityCheck(Object instance) {
-		try {
-			return passesAvailabilityCheck(instance.getClass(), instance);
-		} catch (RuntimeException rte) {
-			LOG.warn("Unable to load service provider {}.", instance.getClass().getName(), rte);
-			return false;
-		}
+		return silentlyPassesAvailabilityCheck(instance.getClass(), instance);
 	}
 
 	private static void logServiceIsAvailable(Class<?> apiType, Class<?> implType) {
 		if (LOG.isDebugEnabled()) {
 			LOG.debug("{}: Implementation is available: {}", apiType.getSimpleName(), implType.getName());
+		}
+	}
+
+	private static <T> boolean silentlyPassesAvailabilityCheck(Class<? extends T> type, @Nullable T instance) {
+		try {
+			return passesAvailabilityCheck(type, instance);
+		} catch (ExceptionInInitializerError | NoClassDefFoundError | RuntimeException e) {
+			LOG.warn("Unable to load service provider {}.", type.getName(), e);
+			return false;
 		}
 	}
 

--- a/src/test/java/org/cryptomator/integrations/common/InitExceptionTestClass.java
+++ b/src/test/java/org/cryptomator/integrations/common/InitExceptionTestClass.java
@@ -1,0 +1,25 @@
+package org.cryptomator.integrations.common;
+
+@CheckAvailability
+public class InitExceptionTestClass {
+
+	private static final String TEST;
+
+	static {
+		TEST = throwSomethig();
+	}
+
+	public InitExceptionTestClass() {
+
+	}
+
+	static String throwSomethig() {
+		throw new RuntimeException("STATIC FAIL");
+	}
+
+	@CheckAvailability
+	public static boolean test() {
+		return true;
+	}
+
+}

--- a/src/test/java/org/cryptomator/integrations/common/InitExceptionTestClass.java
+++ b/src/test/java/org/cryptomator/integrations/common/InitExceptionTestClass.java
@@ -6,14 +6,14 @@ public class InitExceptionTestClass {
 	private static final String TEST;
 
 	static {
-		TEST = throwSomethig();
+		TEST = throwSomething();
 	}
 
 	public InitExceptionTestClass() {
 
 	}
 
-	static String throwSomethig() {
+	static String throwSomething() {
 		throw new RuntimeException("STATIC FAIL");
 	}
 

--- a/src/test/java/org/cryptomator/integrations/common/IntegrationsLoaderTest.java
+++ b/src/test/java/org/cryptomator/integrations/common/IntegrationsLoaderTest.java
@@ -97,6 +97,18 @@ public class IntegrationsLoaderTest {
 			Assertions.assertFalse(IntegrationsLoader.passesStaticAvailabilityCheck(C3.class));
 		}
 
+		@Test
+		@DisplayName("throwing @CheckAvailability methods are treated as false")
+		public void testPassesAvailabilityCheckThrowing() {
+
+			@CheckAvailability class C1 {
+				@CheckAvailability public static boolean test() { throw new RuntimeException("FAIL"); }
+			}
+
+			Assertions.assertFalse(IntegrationsLoader.passesStaticAvailabilityCheck(C1.class));
+			Assertions.assertFalse(IntegrationsLoader.passesStaticAvailabilityCheck(InitExceptionTestClass.class));
+			Assertions.assertFalse(IntegrationsLoader.passesStaticAvailabilityCheck(InitExceptionTestClass.class)); //NoClassDefFoundError due to repated call
+		}
 
 	}
 
@@ -188,6 +200,26 @@ public class IntegrationsLoaderTest {
 			Assertions.assertFalse(IntegrationsLoader.passesInstanceAvailabilityCheck(new C1()));
 			Assertions.assertFalse(IntegrationsLoader.passesInstanceAvailabilityCheck(new C2()));
 			Assertions.assertFalse(IntegrationsLoader.passesInstanceAvailabilityCheck(new C3()));
+		}
+
+
+		@Test
+		@DisplayName("throwing @CheckAvailability methods are treated as false")
+		public void testPassesAvailabilityCheckThrowing() {
+
+			@CheckAvailability
+			class C1 {
+				@CheckAvailability public boolean test1() { throw new RuntimeException("FAIL"); }
+			}
+
+			@CheckAvailability
+			class C2 {
+				@CheckAvailability public boolean test1() { return true; }
+				@CheckAvailability public boolean test2() { throw new RuntimeException("FAIL"); }
+			}
+
+			Assertions.assertFalse(IntegrationsLoader.passesInstanceAvailabilityCheck(new C1()));
+			Assertions.assertFalse(IntegrationsLoader.passesInstanceAvailabilityCheck(new C2()));
 		}
 
 	}


### PR DESCRIPTION
Closes #26.

This PR improves discovery and loading of supported service providers by catching common exceptions/errors during this process (`ExceptionInInitializationError`, `NoClassDefFoundError`, `RuntimeException`).

If one of those throwables are thrown, the service provider is considered as "not supported" and filtered out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved service provider instantiation and error handling in the integration loader.
- **Tests**
	- Added tests to verify the handling of exceptions in service provider availability checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->