### PR TITLE
Feature: Add interface for display name

### DIFF
--- a/src/main/java/org/cryptomator/integrations/common/DisplayName.java
+++ b/src/main/java/org/cryptomator/integrations/common/DisplayName.java
@@ -1,0 +1,21 @@
+package org.cryptomator.integrations.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * A humanreadable name of the annotated class.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@ApiStatus.Experimental
+public @interface DisplayName {
+	String value();
+    
+}

--- a/src/main/java/org/cryptomator/integrations/common/DisplayName.java
+++ b/src/main/java/org/cryptomator/integrations/common/DisplayName.java
@@ -10,6 +10,11 @@ import java.lang.annotation.Target;
 
 /**
  * A humanreadable name of the annotated class.
+ * <p>
+ * Checked in the default implementation of the {@link NamedServiceProvider#getName()} with lower priority.
+ *
+ * @see NamedServiceProvider
+ * @see LocalizedDisplayName
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/cryptomator/integrations/common/LocalizedDisplayName.java
+++ b/src/main/java/org/cryptomator/integrations/common/LocalizedDisplayName.java
@@ -10,6 +10,11 @@ import java.lang.annotation.Target;
 
 /**
  * A humanreadable, localized name of the annotated class.
+ * <p>
+ * Checked in the default implementation of the {@link NamedServiceProvider#getName()} with highest priority.
+ *
+ * @see NamedServiceProvider
+ * @see DisplayName
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/cryptomator/integrations/common/LocalizedDisplayName.java
+++ b/src/main/java/org/cryptomator/integrations/common/LocalizedDisplayName.java
@@ -9,12 +9,26 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * A humanreadable name of the annotated class.
+ * A humanreadable, localized name of the annotated class.
  */
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 @ApiStatus.Experimental
-public @interface DisplayName {
-	String value();
+public @interface LocalizedDisplayName {
+
+	/**
+	 * Name of the localization bundle, where the display name is loaded from.
+	 *
+	 * @return Name of the localization bundle
+	 */
+	String bundle();
+
+	/**
+	 * The localization key containing the display name.
+	 *
+	 * @return Localization key to use
+	 */
+	String key();
+
 }

--- a/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
+++ b/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
@@ -1,24 +1,32 @@
 package org.cryptomator.integrations.common;
 
+import java.util.ResourceBundle;
+
 /**
- * A service provider with a specific, human-readable name.
- * 
+ * A service provider with a human-readable, possibly localized name.
  */
 public interface NamedServiceProvider {
-    
-    /**
-     * Get the name of this service provider.
-     * @implNote The default implementation looks for the {@link DisplayName} annotation and uses its value. If the annotation is not present, it falls back to the qualified class name.
-     * @return The name of the service provider
-     * 
-     * @see DisplayName
-     */
-    default public String getName() {
-        var displayName = this.getClass().getAnnotation(DisplayName.class);
-        if(displayName != null) {
-            return displayName.value();
-        } else {
-            return this.getClass().getName();
-        }
-    }
+
+	/**
+	 * Get the name of this service provider.
+	 *
+	 * @return The name of the service provider
+	 * @implNote The default implementation looks first for a {@link LocalizedDisplayName} and loads the name from the specified resource bundle/key. If the annotation is not present, the code looks for {@link DisplayName} and uses its value. If none of the former annotations are present, it falls back to the qualified class name.
+	 * @see DisplayName
+	 * @see LocalizedDisplayName
+	 */
+	default String getName() {
+		var localizedDisplayName = this.getClass().getAnnotation(LocalizedDisplayName.class);
+		if (localizedDisplayName != null) {
+			return ResourceBundle.getBundle(localizedDisplayName.bundle()) //
+					.getString(localizedDisplayName.key());
+		}
+
+		var displayName = this.getClass().getAnnotation(DisplayName.class);
+		if (displayName != null) {
+			return displayName.value();
+		} else {
+			return this.getClass().getName();
+		}
+	}
 }

--- a/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
+++ b/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
@@ -1,0 +1,24 @@
+package org.cryptomator.integrations.common;
+
+/**
+ * A service provider with a specific, human-readable name.
+ * 
+ */
+public interface NamedServiceProvider {
+    
+    /**
+     * Get the name of this service provider.
+     * @implNote The default implementation looks for the {@link DisplayName} annotation and uses its value. If the annotation is not present, it falls back to the qualified class name.
+     * @return The name of the service provider
+     * 
+     * @see DisplayName
+     */
+    default public String getName() {
+        var displayName = this.getClass().getAnnotation(DisplayName.class);
+        if(displayName != null) {
+            return displayName.value();
+        } else {
+            return this.getClass().getName();
+        }
+    }
+}

--- a/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
+++ b/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
@@ -1,5 +1,8 @@
 package org.cryptomator.integrations.common;
 
+import org.slf4j.LoggerFactory;
+
+import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 /**
@@ -11,15 +14,22 @@ public interface NamedServiceProvider {
 	 * Get the name of this service provider.
 	 *
 	 * @return The name of the service provider
-	 * @implNote The default implementation looks first for a {@link LocalizedDisplayName} and loads the name from the specified resource bundle/key. If the annotation is not present, the code looks for {@link DisplayName} and uses its value. If none of the former annotations are present, it falls back to the qualified class name.
+	 * @implNote The default implementation looks first for a {@link LocalizedDisplayName} and loads the name from the specified resource bundle/key. If the annotation is not present or loading the resource throws an exception, the code looks for {@link DisplayName} and uses its value. If none of the former annotations are present, it falls back to the qualified class name.
 	 * @see DisplayName
 	 * @see LocalizedDisplayName
 	 */
 	default String getName() {
 		var localizedDisplayName = this.getClass().getAnnotation(LocalizedDisplayName.class);
 		if (localizedDisplayName != null) {
-			return ResourceBundle.getBundle(localizedDisplayName.bundle()) //
-					.getString(localizedDisplayName.key());
+			try {
+				return ResourceBundle.getBundle(localizedDisplayName.bundle()) //
+						.getString(localizedDisplayName.key());
+			} catch (MissingResourceException e) {
+				var clazz = this.getClass();
+				var logger = LoggerFactory.getLogger(clazz);
+				logger.warn("Failed to load localized display name for {}. Falling back to not-localized display name/class name.", clazz.getName());
+				logger.debug("Reason for failure of {}.", clazz.getName(), e);
+			}
 		}
 
 		var displayName = this.getClass().getAnnotation(DisplayName.class);

--- a/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
+++ b/src/main/java/org/cryptomator/integrations/common/NamedServiceProvider.java
@@ -27,8 +27,7 @@ public interface NamedServiceProvider {
 			} catch (MissingResourceException e) {
 				var clazz = this.getClass();
 				var logger = LoggerFactory.getLogger(clazz);
-				logger.warn("Failed to load localized display name for {}. Falling back to not-localized display name/class name.", clazz.getName());
-				logger.debug("Reason for failure of {}.", clazz.getName(), e);
+				logger.warn("Failed to load localized display name for {}. Falling back to not-localized display name/class name.", clazz.getName(), e);
 			}
 		}
 


### PR DESCRIPTION
This PR adds the `NamedServiceProvider` interface to the commons package.

The interface is intended to mark services as "has a printable, human readable, possibly localized name" with the method `getName()`. Alongside with the interface, the annotations `@DisplayName` and `@LocalizedDisplayName` are added and the default getName() impl checks for these annotation and falls back to the qualified class name otherwise.

Already existing SPIs are not modified, since this would require changes in a lot of different libraries, which should be done in a separate project.