### PR TITLE
Feature: Cache ClassLoader for pluginDir

### DIFF
--- a/src/main/java/org/cryptomator/integrations/common/ClassLoaderFactory.java
+++ b/src/main/java/org/cryptomator/integrations/common/ClassLoaderFactory.java
@@ -23,7 +23,7 @@ class ClassLoaderFactory {
 
 	/**
 	 * Attempts to find {@code .jar} files in the path specified in {@value #PLUGIN_DIR_KEY} system property.
-	 * A new class loader instance is returned that loads classes from the given classes.
+	 * A new class loader instance is returned that loads classes from the given directory.
 	 *
 	 * @return A new URLClassLoader that is aware of all {@code .jar} files in the plugin dir
 	 */

--- a/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
+++ b/src/main/java/org/cryptomator/integrations/common/IntegrationsLoader.java
@@ -23,6 +23,14 @@ public class IntegrationsLoader {
 	private IntegrationsLoader() {
 	}
 
+	private static class PluginClassLoaderHolder {
+		private static final ClassLoader CLASS_LOADER = ClassLoaderFactory.forPluginDir();
+	}
+
+	private static ClassLoader getClassLoader() {
+		return PluginClassLoaderHolder.CLASS_LOADER;
+	}
+
 	/**
 	 * Loads the best suited service provider, i.e. the one with the highest priority that is supported.
 	 * <p>
@@ -44,7 +52,7 @@ public class IntegrationsLoader {
 	 * @param <T> Type of the service
 	 */
 	public static <T> Optional<T> loadSpecific(Class<T> clazz, String implementationClassName) {
-		return ServiceLoader.load(clazz, ClassLoaderFactory.forPluginDir()).stream()
+		return ServiceLoader.load(clazz, getClassLoader()).stream()
 				.filter(provider -> provider.type().getName().equals(implementationClassName))
 				.map(ServiceLoader.Provider::get)
 				.findAny();
@@ -61,7 +69,7 @@ public class IntegrationsLoader {
 	 * @return An ordered stream of all suited service providers
 	 */
 	public static <T> Stream<T> loadAll(Class<T> clazz) {
-		return loadAll(ServiceLoader.load(clazz, ClassLoaderFactory.forPluginDir()), clazz);
+		return loadAll(ServiceLoader.load(clazz, getClassLoader()), clazz);
 	}
 
 	/**


### PR DESCRIPTION
This PR changes the loading of plugins.

Currently, calling `IntegrationsLoader::loadX` method creates a new class loader. The class loader completely traverses the pluginDirectory. If there are many plugins or deeply nested ones, loading specific services takes a long time. _Every time_ a certain service is loaded.

This PR adds a thread-safe, lazily initialized cache for the class loader, which is initialized once and never invalidated. It reduces the look up time of consecutive service implementations and ensures that only one file handle to each plugin file is created.

Important implication is, that **once any service is loaded, changes to the plugin directory or the plugin directory property  have no effect**.