### PR TITLE
Downgrade jackson to 2.21.*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "com.fasterxml.jackson.*"
+        versions: [ "[2.22,)" ] # 2.21.x is LTS, see https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.21
     groups:
       maven-dependencies:
         patterns:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Changes to prior versions can be found on the [Github release page](https://gith
 
 ## [Unreleased](https://github.com/cryptomator/integrations-api/compare/1.9.0...HEAD)
 
-No changes yet.
+### Changed
+* Updated dependencies:
+  - `com.fasterxml.jackson.core:jackson-databind` from `2.22.0` to `2.21.6` (2.21.x is LTS)
 
 
 ## [1.9.0](https://github.com/cryptomator/integrations-api/compare/1.9.0) - 2026-06-22

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<jdk.version>25</jdk.version>
 
 		<slf4j.version>2.0.18</slf4j.version>
-		<jackson.version>2.22.0</jackson.version>
+		<jackson.version>2.21.6</jackson.version>
 		<jetbrains-annotation.version>26.1.0</jetbrains-annotation.version>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
and adjust dependabot config.

We do not use features from 2.22 branch and it would make more sense to migrate directly to jackson 3.